### PR TITLE
Allow using the runner programmatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,13 @@
 ### ✨ Improved
 
 * [#15](https://github.com/sdss/lvmcryo/pull/15) `lvmcryo.runner.ln2_runner` can now be called programmatically with the same functionality as the CLI. The CLI has been modified to use `ln2_runner` without changes in behaviour.
+* [#15](https://github.com/sdss/lvmcryo/pull/15) Added ``abort`` CLI command.
 * No need to run `pyenv shell --unset` in the manual fill script since it runs in its own shell.
 * Add wait time before starting manual fill to allow other fills to be aborted.
+
+### 🔧 Fixed
+
+* [#15](https://github.com/sdss/lvmcryo/pull/15) Various fixes to ensure that removing the lock file cancels all ongoing fills.
 
 
 ## 0.4.2 - 2026-01-09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### ✨ Improved
 
+* [#15](https://github.com/sdss/lvmcryo/pull/15) `lvmcryo.runner.ln2_runner` can now be called programmatically with the same functionality as the CLI. The CLI has been modified to use `ln2_runner` without changes in behaviour.
 * No need to run `pyenv shell --unset` in the manual fill script since it runs in its own shell.
 * Add wait time before starting manual fill to allow other fills to be aborted.
 

--- a/src/lvmcryo/__main__.py
+++ b/src/lvmcryo/__main__.py
@@ -562,7 +562,26 @@ def list_profiles(
 
 
 @cli.command("clear-lock")
-def clear_lock():
+@cli_coro()
+async def clear_lock(
+    wait: Annotated[
+        bool,
+        Option(
+            "--wait/--no-wait",
+            help="Waits a few seconds after removing the lock file to allow other "
+            "processes to stop.",
+            show_default=True,
+        ),
+    ] = True,
+    wait_delay: Annotated[
+        float,
+        Option(
+            "--wait-delay",
+            help="Time in seconds to wait after removing the lock file.",
+            show_default=True,
+        ),
+    ] = 10.0,
+):
     """Clears the lock file if it exists."""
 
     from lvmcryo.config import get_internal_config
@@ -573,6 +592,14 @@ def clear_lock():
     if lockfile_path.exists():
         lockfile_path.unlink()
         info_console.print("[green]Lock file removed.[/]")
+
+        if wait:
+            wait_delay = int(wait_delay)
+            info_console.print(
+                f"[gray]Waiting {wait_delay} seconds for other processes to stop.[/]"
+            )
+            await asyncio.sleep(wait_delay)
+
     else:
         info_console.print("[yellow]No lock file found.[/]")
 

--- a/src/lvmcryo/__main__.py
+++ b/src/lvmcryo/__main__.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import enum
+import os
 import pathlib
 import signal
 from functools import wraps
@@ -17,17 +18,19 @@ from functools import wraps
 from typing import Annotated, Optional, cast
 
 import typer
+from click.core import ParameterSource
 from rich.console import Console
 from typer import Argument, Option
 from typer.core import TyperGroup
 
-from lvmcryo.config import Actions, InteractiveMode, NotificationLevel
+from lvmcryo.config import Actions, InteractiveMode, NotificationLevel, ParameterOrigin
 
-
-LOCKFILE = pathlib.Path("/data/lvmcryo.lock")
 
 info_console = Console()
 err_console = Console(stderr=True)
+
+
+DEBUG = os.environ.get("LVMCRYO_DEBUG", "").lower() not in ["", "0", "false"]
 
 
 def cli_coro(
@@ -43,6 +46,10 @@ def cli_coro(
             if shutdown_func:
                 for ss in signals:
                     loop.add_signal_handler(ss, shutdown_func, ss, loop)
+
+            if loop.is_running():
+                return asyncio.create_task(f(*args, **kwargs))
+
             return loop.run_until_complete(f(*args, **kwargs))
 
         return wrapper
@@ -88,6 +95,7 @@ def main(
     ] = None,
 ):
     """CLI for LVM cryostats."""
+
     pass
 
 
@@ -426,52 +434,31 @@ async def ln2(
 
     """
 
-    from logging import FileHandler
-    from tempfile import NamedTemporaryFile
-
-    from rich.prompt import Confirm
-
     from sdsstools.logger import get_logger
 
-    from lvmcryo import __version__
-    from lvmcryo.config import Config
-    from lvmcryo.handlers.ln2 import LN2Handler, get_now
-    from lvmcryo.notifier import Notifier
-    from lvmcryo.runner import ln2_runner, post_fill_tasks
-    from lvmcryo.tools import (
-        DBHandler,
-        LockExistsError,
-        add_json_handler,
-        ensure_lock,
-    )
-    from lvmcryo.validate import validate_fill
+    from lvmcryo.runner import LN2RunnerError, ln2_runner
+    from lvmcryo.tools import LockExistsError
 
-    # Create log here and use its console for stdout.
     log = get_logger("lvmcryo", use_rich_handler=True)
     log.setLevel(5)
 
-    stdout_console = log.rich_console
-    assert stdout_console is not None
-
-    error: Exception | str | None = None
-    skip_finally: bool = False
-
-    json_path: pathlib.Path | None = None
-    json_handler: FileHandler | None = None
-    images: dict[str, pathlib.Path | None] = {}
-
-    if action == Actions.abort:
-        return await _close_valves_helper()
-    elif action == Actions.clear_lock:
-        if LOCKFILE.exists():
-            LOCKFILE.unlink()
-            stdout_console.print("[green]Lock file removed.[/]")
-        else:
-            stdout_console.print("[yellow]No lock file found.[/]")
-        return
-
     try:
-        config = Config(
+        # Determine parameter origins. The config uses this information to
+        # decide whether a profile parameter should be overridden or not.
+        param_origin: dict[str, ParameterOrigin | None] = {}
+        for param in ctx.params:
+            source = ctx.get_parameter_source(param)
+            match source:
+                case ParameterSource.COMMANDLINE:
+                    param_origin[param] = ParameterOrigin.COMMAND_LINE
+                case ParameterSource.DEFAULT:
+                    param_origin[param] = ParameterOrigin.DEFAULT
+                case ParameterSource.ENVIRONMENT:
+                    param_origin[param] = ParameterOrigin.ENVVAR
+                case _:
+                    param_origin[param] = None
+
+        await ln2_runner(
             action=action,
             cameras=cameras or [],
             config_file=config_file,
@@ -505,110 +492,10 @@ async def ln2(
             write_data=write_data,
             data_path=data_path,
             data_extra_time=data_extra_time,
-            version=__version__,
             profile=profile,
-            # We cannot pass the context directly so we pass a dict of the
-            # origin of each parameter to reject profile parameters that
-            # have been manually defined.
-            param_source={pp: ctx.get_parameter_source(pp) for pp in ctx.params},
+            log=log,
+            __parameter_origin=param_origin,
         )
-    except ValueError as err:
-        err_console.print(f"[red]Error parsing configuration:[/] {err}")
-        raise typer.Exit(1)
-
-    if config.write_log and config.log_path:
-        log.start_file_logger(str(config.log_path))
-
-        if config.write_json:
-            json_path = config.log_path.with_suffix(".json")
-            json_handler = add_json_handler(log, json_path)
-
-    else:
-        # We're still creating log files, but to a temporary location. This is
-        # just to be able to send the log body in a notification email and include
-        # it when loading the DB.
-        temp_file = NamedTemporaryFile()
-        log.start_file_logger(temp_file.name)
-        json_path = pathlib.Path(temp_file.name).with_suffix(".json")
-        json_handler = add_json_handler(log, json_path)
-
-    if verbose:
-        log.sh.setLevel(5)
-    if quiet:
-        log.sh.setLevel(30)
-
-    # Always create a notifier. If the element is disabled the
-    # notifier won't do anything. This simplifies the code.
-    notifier = Notifier(config.internal_config)
-    notifier.disabled = not config.notify
-    notifier.slack_disabled = not config.slack
-    notifier.email_disabled = not config.email
-
-    if not config.notify:
-        log.debug("Notifications are disabled and will not be emitted.")
-
-    if config.config_file is not None:
-        log.info(f"Using configuration file: {config.config_file!s}")
-
-    if not config.no_prompt:
-        stdout_console.print(f"Action {config.action.value} will run with:")
-        stdout_console.print(config.model_dump())
-        if not Confirm.ask(
-            "Continue with this configuration?",
-            default=False,
-            show_default=True,
-            console=stdout_console,
-        ):
-            return typer.Exit(0)
-
-    # Create the LN2 handler.
-    handler = LN2Handler(
-        config.cameras,
-        interactive=config.interactive == "yes",
-        log=log,
-        valve_info=config.valve_info,
-        dry_run=config.dry_run,
-        alerts_route=config.internal_config["api_routes"]["alerts"],
-        check_o2_sensors=config.check_o2_sensors,
-    )
-
-    if LOCKFILE.exists() and config.clear_lock:
-        log.warning("Lock file exists. Removing it because --clear-lock.")
-        LOCKFILE.unlink()
-
-    db_handler = DBHandler(action, handler, config, json_handler=json_handler)
-    record_pk = await db_handler.write(complete=False)
-    if record_pk:
-        log.debug(f"Record {record_pk} created in the database.")
-
-    try:
-        async with ensure_lock(
-            LOCKFILE,
-            monitor=True,
-            exit=True,
-            on_release_callback=handler.abort(raise_error=False, close_valves=True),
-        ):
-            # Calculate the expected maximum run time.
-            max_time: float = 2 * 3600  # It should never take longer than two hours.
-            if config.max_purge_time is not None and config.max_fill_time is not None:
-                max_time = config.max_purge_time + config.max_fill_time + 300.0
-
-            # Run worker.
-            await asyncio.wait_for(
-                ln2_runner(
-                    handler,
-                    config,
-                    notifier,
-                    db_handler=db_handler,
-                ),
-                timeout=max_time,
-            )
-
-            # Check handler status.
-            if handler.failed:
-                raise RuntimeError(
-                    "No exceptions were raised but the LN2 handler reports a failure."
-                )
 
     except LockExistsError:
         err_console.print(
@@ -616,141 +503,22 @@ async def ln2(
             "performing an operation. Use [green]lvmcryo ln2 clear-lock[/] to remove "
             "the lock."
         )
-
-        if config.notify:
-            log.warning("Sending failure notifications.")
-            await notifier.notify_after_fill(
-                False,
-                error_message=f"LN2 {action.value} failed because a lockfile "
-                "was already present.",
-            )
-
-        # Do not do anything special for this error, just exit.
-        skip_finally = True
-
         raise typer.Exit(1)
 
     except Exception as err:
-        # Log the traceback to file but do not print.
-        orig_sh_level = log.sh.level
-        log.sh.setLevel(1000)
+        # Hide the traceback unless with_traceback or DEBUG is set, but always log it
+        # to the file, if we are doing that.
+        log.sh.setLevel(10000)
 
-        log.exception(f"Error during {action.value}: {err!s}", exc_info=err)
-        if isinstance(err, asyncio.TimeoutError):
-            log.error("One or more operations timed out.")
+        log.exception("Error raised in LN2 runner.", exc_info=err)
+        err_console.print(f"[red]LN2 operation failed:[/] {err}")
 
-        log.sh.setLevel(orig_sh_level)
-
-        # Fail the action.
-        handler.failed = True
-        skip_finally = True
-
-        error = err
-        if config.with_traceback:
+        if (isinstance(err, LN2RunnerError) and err.propagate) or DEBUG:
             raise
 
         raise typer.Exit(1)
 
-    else:
-        log.info(f"LN2 {action.value} completed successfully.")
-
-    finally:
-        # At this point all the valves are closed so we can remove the signal handlers.
-        for signame in ("SIGINT", "SIGTERM"):
-            asyncio.get_running_loop().remove_signal_handler(getattr(signal, signame))
-
-        handler.event_times.end_time = get_now()
-        await handler.clear()
-
-        log.info(f"Event times:\n{handler.event_times.model_dump_json(indent=2)}")
-
-        # Make sure all valves are closed.
-        try:
-            log.info("Ensuring all valves are closed.")
-            await asyncio.wait_for(
-                handler.stop(only_active=False, close_valves=True),
-                timeout=30,
-            )
-        except Exception as err:
-            log.error(f"Error closing valves before exiting: {err}")
-
-        if not skip_finally:
-            # Do a quick update of the DB record since post_fill_tasks() may
-            # block for a long time.
-            await db_handler.write(error=error)
-
-            plot_paths = await post_fill_tasks(
-                handler,
-                notifier=notifier,
-                write_data=config.write_data,
-                data_path=config.data_path,
-                data_extra_time=config.data_extra_time if error is None else None,
-                api_data_route=config.internal_config["api_routes"]["fill_data"],
-            )
-
-            if (
-                config.write_data
-                and config.data_path
-                and config.data_path.exists()
-                and not error
-            ):
-                validate_failed, validate_error = validate_fill(
-                    handler,
-                    config,
-                    log=log,
-                )
-                if validate_failed and error is None:
-                    await notifier.post_to_slack(
-                        "Fill validation failed. Check the log for details.",
-                        level=NotificationLevel.error,
-                    )
-                    handler.failed = True
-                    error = validate_error
-                elif not validate_failed:
-                    log.info("Fill validation completed successfully.")
-
-            log.info("Writing fill metadata to database.")
-            await db_handler.write(complete=True, plot_paths=plot_paths, error=error)
-
-            if config.notify:
-                images = {
-                    "pressure": plot_paths.get("pressure_png", None),
-                    "temps": plot_paths.get("temps_png", None),
-                    "thermistors": plot_paths.get("thermistors_png", None),
-                }
-
-                if error:
-                    log.warning("Sending failure notifications.")
-                    await notifier.notify_after_fill(
-                        False,
-                        error_message=error,
-                        handler=handler,
-                        images=images,
-                        record_pk=record_pk,
-                    )
-
-                elif config.email_level == NotificationLevel.info:
-                    # The handler has already emitted a notification to
-                    # Slack so just send an email.
-
-                    # TODO: include log and more data here.
-                    # For now it's just plain text.
-
-                    log.info("Sending notification email.")
-                    await notifier.notify_after_fill(
-                        True,
-                        handler=handler,
-                        images=images,
-                        post_to_slack=False,  # Already done.
-                        record_pk=record_pk,
-                    )
-
-            if error:
-                # Last message before existing.
-                err_console.print(f"[red]Error found during {action.value}:[/] {error}")
-
-    if error:
-        raise typer.Exit(1)
+    return typer.Exit(0)
 
 
 async def _close_valves_helper():
@@ -797,8 +565,13 @@ def list_profiles(
 def clear_lock():
     """Clears the lock file if it exists."""
 
-    if LOCKFILE.exists():
-        LOCKFILE.unlink()
+    from lvmcryo.config import get_internal_config
+
+    config = get_internal_config()
+    lockfile_path = pathlib.Path(config.get("lockfile", "/data/lvmcryo.lock"))
+
+    if lockfile_path.exists():
+        lockfile_path.unlink()
         info_console.print("[green]Lock file removed.[/]")
     else:
         info_console.print("[yellow]No lock file found.[/]")

--- a/src/lvmcryo/__main__.py
+++ b/src/lvmcryo/__main__.py
@@ -606,6 +606,19 @@ async def clear_lock(
     return typer.Exit(0)
 
 
+@cli.command("abort")
+@cli_coro()
+async def abort():
+    """Aborts an ongoing purge/fill and closes all the valves.
+
+    Equivalent of calling close-valves and clear-lock.
+
+    """
+
+    await close_valves()
+    await clear_lock(wait=True)
+
+
 @cli.command("close-valves")
 @cli_coro()
 async def close_valves():

--- a/src/lvmcryo/config.yaml
+++ b/src/lvmcryo/config.yaml
@@ -13,14 +13,38 @@ defaults:
 
 profiles:
   production:
+    use_thermistors: true
     clear_lock: true
     interactive: 'no'
     notify: true
-    with_traceback: true
     write_log: true
     write_data: true
     write_json: true
     email_level: info
+    with_traceback: true
+    data_extra_time: 1200
+  manual-fill:
+    use_thermistors: true
+    clear_lock: false
+    interactive: 'no'
+    notify: false
+    write_log: true
+    write_data: false
+    write_json: true
+    email_level: info
+    with_traceback: true
+  timed-fill:
+    use_thermistors: false
+    max_purge_time: 2100
+    max_fill_time: 360
+    clear_lock: false
+    interactive: 'no'
+    notify: true
+    write_log: true
+    write_data: true
+    write_json: true
+    email_level: info
+    with_traceback: true
     data_extra_time: 1200
 
 notifications:

--- a/src/lvmcryo/config.yaml
+++ b/src/lvmcryo/config.yaml
@@ -11,6 +11,8 @@ defaults:
   data_path: '/data/logs/lvmcryo/{timestamp}.parquet'
   max_temperature_increase: 1
 
+lockfile: /data/lvmcryo.lock
+
 profiles:
   production:
     use_thermistors: true

--- a/src/lvmcryo/runner.py
+++ b/src/lvmcryo/runner.py
@@ -378,7 +378,6 @@ async def ln2_runner(
         async with ensure_lock(
             lockfile_path,
             monitor=True,
-            exit=True,
             on_release_callback=handler.abort(raise_error=False, close_valves=True),
         ):
             # Calculate the expected maximum run time.

--- a/src/lvmcryo/runner.py
+++ b/src/lvmcryo/runner.py
@@ -378,6 +378,7 @@ async def ln2_runner(
         async with ensure_lock(
             lockfile_path,
             monitor=True,
+            log=log,
             on_release_callback=handler.abort(raise_error=False, close_valves=True),
         ):
             # Calculate the expected maximum run time.

--- a/src/lvmcryo/runner.py
+++ b/src/lvmcryo/runner.py
@@ -15,26 +15,43 @@ import pathlib
 import signal
 import sys
 from datetime import timedelta
+from logging import FileHandler
+from tempfile import NamedTemporaryFile
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 import httpx
 import polars
+from rich.prompt import Confirm
 
+from sdsstools.logger import get_logger
 from sdsstools.utils import run_in_executor
 
-from lvmcryo.config import Actions
+from lvmcryo import __version__
+from lvmcryo.config import (
+    Actions,
+    Config,
+    InteractiveMode,
+    NotificationLevel,
+    ParameterOrigin,
+)
 from lvmcryo.handlers import LN2Handler, close_all_valves
 from lvmcryo.handlers.ln2 import get_now
 from lvmcryo.notifier import Notifier
+from lvmcryo.tools import (
+    DBHandler,
+    LockExistsError,
+    add_json_handler,
+    ensure_lock,
+    register_parameter_origin,
+)
+from lvmcryo.validate import validate_fill
 
 
 if TYPE_CHECKING:
-    from lvmcryo.config import Config
-    from lvmcryo.tools import DBHandler
+    from sdsstools.logger import SDSSLogger
 
-
-__all__ = ["ln2_runner"]
+__all__ = ["fill_runner", "ln2_runner"]
 
 
 async def signal_handler(handler: LN2Handler, log: logging.Logger):
@@ -63,7 +80,460 @@ async def signal_handler(handler: LN2Handler, log: logging.Logger):
     sys.exit(1)
 
 
+class LN2RunnerError(Exception):
+    """An error occurred during the LN2 runner execution."""
+
+    def __init__(self, *args, propagate: bool = False, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.propagate = propagate
+
+
+@register_parameter_origin
 async def ln2_runner(
+    action: Literal["purge", "fill", "purge-and-fill"] = "purge-and-fill",
+    cameras: list[str] | None = None,
+    profile: str | None = None,
+    config_file: pathlib.Path | None = None,
+    dry_run: bool = False,
+    interactive: Literal["auto", True, False, "yes", "no"] = False,
+    no_prompt: bool = True,
+    with_traceback: bool = False,
+    clear_lock: bool = False,
+    use_thermistors: bool = True,
+    require_all_thermistors: bool = False,
+    check_pressures: bool = True,
+    check_temperatures: bool = True,
+    check_o2_sensors: bool = True,
+    max_pressure: float | None = None,
+    max_temperature: float | None = None,
+    purge_time: float | None = None,
+    min_purge_time: float | None = None,
+    max_purge_time: float | None = None,
+    fill_time: float | None = None,
+    min_fill_time: float | None = None,
+    max_fill_time: float | None = None,
+    notify: bool = False,
+    slack: bool = True,
+    email: bool = True,
+    email_level: Literal["error", "info"] = "error",
+    quiet: bool = False,
+    verbose: bool = False,
+    write_log: bool = False,
+    log_path: pathlib.Path | None = None,
+    write_json: bool = True,
+    write_data: bool = False,
+    data_path: pathlib.Path | None = None,
+    data_extra_time: float = 60,
+    log: SDSSLogger | None = None,
+    __parameter_origin: dict[str, ParameterOrigin | None] = {},
+):
+    """Runs LN2 purge/fill/abort/clear actions.
+
+    This is a wrapper allowing the CLI functionality to be called programmatically.
+
+    Parameters
+    ----------
+    action
+        The action to perform. One of ``purge``, ``fill``, or ``purge-and-fill``.
+    cameras
+        The cameras to fill. Defaults to all cameras. Ignored for ``purge``, ``abort``
+        and ``clear_lock``.
+    profile
+        The profile to use.
+    config_file
+        The configuration file. Defaults to the internal configuration file.
+    dry_run
+        Test run the code but do not actually open/close any valves.
+    interactive
+        Controls whether the interactive features are shown.
+        When ``auto`` (the default), interactivity is determined based
+        on the console mode.
+    no_prompt
+        Does not prompt the user to finish or abort a purge/fill.
+        Prompting is required if ``fill_time`` or ``purge_time`` are not provided
+        and thermistors are not used.
+    with_traceback
+        Show the full traceback in case of an error. If not set, only the error message
+        is shown. The full traceback is always logged to the log file.
+    clear_lock
+        Clears the lock file if it exists before carrying out the action.
+    use_thermistors
+        Use thermistor values to determine purge/fill time.
+    require_all_thermistors
+        If set, waits until all thermistors have activated before closing any of the
+        valves. This prevents over-pressures in the cryostats when only some
+        of the valves are open. Ignored if ``use_thermistors=False``.
+    check_pressures
+        Aborts purge/fill if the pressure of any cryostat is above the limit.
+    check_temperatures
+        Aborts purge/fill if the temperature of a fill cryostat is above the limit.
+    check_o2_sensors
+        Aborts purge/fill if the oxygen sensor reads below the limit.
+    max_pressure
+        Maximum cryostat pressure if ``--check-pressure``. Defaults to internal value.
+    max_temperature
+        Maximum cryostat temperature if ``check_temperature=True``.
+        Defaults to internal value.
+    purge_time
+        Purge time in seconds. If ``use_thermistors=True``, this is used
+        as the maximum purge time.
+    min_purge_time
+        Minimum purge time in seconds. Defaults to internal value.
+    max_purge_time
+        Maximum purge time in seconds. Defaults to internal value.
+    fill_time
+        Fill time in seconds. If ``use_thermistors=True``, this is used as
+        the maximum fill time.
+    min_fill_time
+        Minimum fill time in seconds. Defaults to internal value.
+    max_fill_time
+        Maximum fill time in seconds. Defaults to internal value.
+    notify
+        Sends a notification when the action is completed. In not set,
+        ``slack`` and ``email`` are ignored. Notifications are not sent
+        for the ``abort`` and ``clear-lock`` actions.
+    slack
+        Send a Slack notification when the action is completed.
+    email
+        Send an email notification when the action is completed.
+    email_level
+        Send an email notification only on error or always.
+    quiet
+        Disable logging to stdout.
+    verbose
+        Outputs additional information to stdout.
+    write_log
+        Saves the log to a file.
+    log_path
+        Path where to save the log file. Implies ``write_log=True``.
+        Defaults to the current directory.
+    write_json
+        Saves the log in JSON format. Uses the same path as the file log. Ignored if
+        ``write_log`` is not passed.
+    write_data
+        Saves cryostat pressures and temperatures taken during purge/fill to a
+        parquet file.
+    data_path
+        Path where to save the data. Implies ``write_data=True``.
+        Defaults to a path relative to the log path.
+    data_extra_time
+        Additional time to take cryostat data after the action has been completed.
+        The command will not complete until data collection has finished.
+    log
+        The logger instance to use. If `None`, a new logger is created.
+    __parameter_origin
+        Used internally to track parameter origins. Do not pass this parameter
+        manually.
+
+    """
+
+    try:
+        action_enum = Actions(action)
+
+        if interactive is True:
+            interactive = "yes"
+        elif interactive is False:
+            interactive = "no"
+        interactive_enum = InteractiveMode(interactive)
+
+        email_level_enum = NotificationLevel(email_level)
+
+        config = Config(
+            action=action_enum,
+            cameras=cameras or [],
+            config_file=config_file,
+            dry_run=dry_run,
+            clear_lock=clear_lock,
+            with_traceback=with_traceback,
+            interactive=interactive_enum,
+            no_prompt=no_prompt,
+            notify=notify,
+            slack=slack,
+            email=email,
+            email_level=email_level_enum,
+            use_thermistors=use_thermistors,
+            require_all_thermistors=require_all_thermistors,
+            check_pressures=check_pressures,
+            check_temperatures=check_temperatures,
+            check_o2_sensors=check_o2_sensors,
+            max_pressure=max_pressure,
+            max_temperature=max_temperature,
+            purge_time=purge_time,
+            min_purge_time=min_purge_time,
+            max_purge_time=max_purge_time,
+            fill_time=fill_time,
+            min_fill_time=min_fill_time,
+            max_fill_time=max_fill_time,
+            quiet=quiet,
+            verbose=verbose,
+            write_log=write_log,
+            write_json=write_json,
+            log_path=log_path,
+            write_data=write_data,
+            data_path=data_path,
+            data_extra_time=data_extra_time,
+            version=__version__,
+            profile=profile,
+            param_origin=__parameter_origin,
+        )
+        internal_config = config.internal_config
+    except Exception as err:
+        raise LN2RunnerError(f"Error parsing configuration: {err!r}") from err
+
+    # Create log here and use its console for stdout.
+    if log is None:
+        log = get_logger("lvmcryo", use_rich_handler=True)
+        log.setLevel(5)
+
+    stdout_console = log.rich_console
+    assert stdout_console is not None
+
+    error: Exception | None = None
+    skip_finally: bool = False
+
+    json_path: pathlib.Path | None = None
+    json_handler: FileHandler | None = None
+    images: dict[str, pathlib.Path | None] = {}
+
+    if config.write_log and config.log_path:
+        log.start_file_logger(str(config.log_path))
+
+        if config.write_json:
+            json_path = config.log_path.with_suffix(".json")
+            json_handler = add_json_handler(log, json_path)
+
+    else:
+        # We're still creating log files, but to a temporary location. This is
+        # just to be able to send the log body in a notification email and include
+        # it when loading the DB.
+        temp_file = NamedTemporaryFile()
+        log.start_file_logger(temp_file.name)
+        json_path = pathlib.Path(temp_file.name).with_suffix(".json")
+        json_handler = add_json_handler(log, json_path)
+
+    if verbose:
+        log.sh.setLevel(5)
+    if quiet:
+        log.sh.setLevel(30)
+
+    # Always create a notifier. If the element is disabled the
+    # notifier won't do anything. This simplifies the code.
+    notifier = Notifier(internal_config)
+    notifier.disabled = not config.notify
+    notifier.slack_disabled = not config.slack
+    notifier.email_disabled = not config.email
+
+    if not config.notify:
+        log.debug("Notifications are disabled and will not be emitted.")
+
+    if config.config_file is not None:
+        log.info(f"Using configuration file: {config.config_file!s}")
+
+    if not config.no_prompt:
+        stdout_console.print(f"Action {config.action.value} will run with:")
+        stdout_console.print(config.model_dump())
+        if not Confirm.ask(
+            "Continue with this configuration?",
+            default=False,
+            show_default=True,
+            console=stdout_console,
+        ):
+            return False
+
+    # Create the LN2 handler.
+    try:
+        handler = LN2Handler(
+            config.cameras,
+            interactive=config.interactive == "yes",
+            log=log,
+            valve_info=config.valve_info,
+            dry_run=config.dry_run,
+            alerts_route=internal_config["api_routes"]["alerts"],
+            check_o2_sensors=config.check_o2_sensors,
+        )
+    except Exception as err:
+        raise LN2RunnerError(
+            f"Error creating LN2 handler: {err!r}",
+            propagate=config.with_traceback,
+        ) from err
+
+    lockfile_path = pathlib.Path(internal_config.get("lockfile", "/data/lvmcryo.lock"))
+
+    if lockfile_path.exists() and config.clear_lock:
+        log.warning("Lock file exists. Removing it because --clear-lock.")
+        lockfile_path.unlink()
+
+    try:
+        db_handler = DBHandler(action, handler, config, json_handler=json_handler)
+        record_pk = await db_handler.write(complete=False)
+        if record_pk:
+            log.debug(f"Record {record_pk} created in the database.")
+    except Exception as err:
+        raise LN2RunnerError(
+            f"Error creating database record: {err!r}",
+            propagate=config.with_traceback,
+        ) from err
+
+    try:
+        async with ensure_lock(
+            lockfile_path,
+            monitor=True,
+            exit=True,
+            on_release_callback=handler.abort(raise_error=False, close_valves=True),
+        ):
+            # Calculate the expected maximum run time.
+            max_time: float = 2 * 3600  # It should never take longer than two hours.
+            if config.max_purge_time is not None and config.max_fill_time is not None:
+                max_time = config.max_purge_time + config.max_fill_time + 300.0
+
+            # Run worker.
+            await asyncio.wait_for(
+                fill_runner(
+                    handler,
+                    config,
+                    notifier,
+                    db_handler=db_handler,
+                ),
+                timeout=max_time,
+            )
+
+            # Check handler status.
+            if handler.failed:
+                raise RuntimeError(
+                    "No exceptions were raised but the LN2 handler reports a failure."
+                )
+
+    except LockExistsError:
+        if config.notify:
+            log.warning("Sending failure notifications.")
+            await notifier.notify_after_fill(
+                False,
+                error_message=f"LN2 {config.action.value} failed because a lockfile "
+                "was already present.",
+            )
+
+        # Do not do anything special for this error, just exit.
+        skip_finally = True
+
+        raise
+
+    except Exception as err:
+        # Log the traceback to file but do not print.
+        orig_sh_level = log.sh.level
+        log.sh.setLevel(1000)
+
+        log.exception(f"Error during {config.action.value}: {err!s}", exc_info=err)
+        if isinstance(err, asyncio.TimeoutError):
+            log.error("One or more operations timed out.")
+
+        log.sh.setLevel(orig_sh_level)
+
+        # Fail the action.
+        handler.failed = True
+        skip_finally = True
+
+        error = err
+        raise LN2RunnerError(str(err), propagate=config.with_traceback) from err
+
+    else:
+        log.info(f"LN2 {config.action.value} completed successfully.")
+
+    finally:
+        # At this point all the valves are closed so we can remove the signal handlers.
+        for signame in ("SIGINT", "SIGTERM"):
+            asyncio.get_running_loop().remove_signal_handler(getattr(signal, signame))
+
+        handler.event_times.end_time = get_now()
+        await handler.clear()
+
+        log.info(f"Event times:\n{handler.event_times.model_dump_json(indent=2)}")
+
+        # Make sure all valves are closed.
+        try:
+            log.info("Ensuring all valves are closed.")
+            await asyncio.wait_for(
+                handler.stop(only_active=False, close_valves=True),
+                timeout=30,
+            )
+        except Exception as err:
+            log.error(f"Error closing valves before exiting: {err}")
+
+        if not skip_finally:
+            # Do a quick update of the DB record since post_fill_tasks() may
+            # block for a long time.
+            await db_handler.write(error=error)
+
+            plot_paths = await post_fill_tasks(
+                handler,
+                notifier=notifier,
+                write_data=config.write_data,
+                data_path=config.data_path,
+                data_extra_time=config.data_extra_time if error is None else None,
+                api_data_route=internal_config["api_routes"]["fill_data"],
+            )
+
+            if (
+                config.write_data
+                and config.data_path
+                and config.data_path.exists()
+                and not error
+            ):
+                validate_failed, validate_error = validate_fill(
+                    handler,
+                    config,
+                    log=log,
+                )
+                if validate_failed and error is None:
+                    await notifier.post_to_slack(
+                        "Fill validation failed. Check the log for details.",
+                        level=NotificationLevel.error,
+                    )
+                    handler.failed = True
+                    error = RuntimeError(validate_error)
+                elif not validate_failed:
+                    log.info("Fill validation completed successfully.")
+
+            log.info("Writing fill metadata to database.")
+            await db_handler.write(complete=True, plot_paths=plot_paths, error=error)
+
+            if config.notify:
+                images = {
+                    "pressure": plot_paths.get("pressure_png", None),
+                    "temps": plot_paths.get("temps_png", None),
+                    "thermistors": plot_paths.get("thermistors_png", None),
+                }
+
+                if error:
+                    log.warning("Sending failure notifications.")
+                    await notifier.notify_after_fill(
+                        False,
+                        error_message=error,
+                        handler=handler,
+                        images=images,
+                        record_pk=record_pk,
+                    )
+
+                elif config.email_level == NotificationLevel.info:
+                    # The handler has already emitted a notification to
+                    # Slack so just send an email.
+
+                    # TODO: include log and more data here.
+                    # For now it's just plain text.
+
+                    log.info("Sending notification email.")
+                    await notifier.notify_after_fill(
+                        True,
+                        handler=handler,
+                        images=images,
+                        post_to_slack=False,  # Already done.
+                        record_pk=record_pk,
+                    )
+
+            if error:
+                raise error
+
+
+async def fill_runner(
     handler: LN2Handler,
     config: Config,
     notifier: Notifier | None = None,

--- a/src/lvmcryo/tools.py
+++ b/src/lvmcryo/tools.py
@@ -234,7 +234,9 @@ async def _monitor_lockfile(
     while True:
         if not lockfile.exists():
             if on_release_callback:
-                if asyncio.iscoroutinefunction(on_release_callback):
+                if asyncio.iscoroutine(on_release_callback):
+                    await on_release_callback
+                elif asyncio.iscoroutinefunction(on_release_callback):
                     await on_release_callback()
                 else:
                     on_release_callback()
@@ -290,7 +292,7 @@ async def ensure_lock(
         yield
     finally:
         await cancel_task(monitor_task)
-        lockfile.unlink()
+        lockfile.unlink(missing_ok=True)
 
 
 def get_fake_logger():

--- a/src/lvmcryo/tools.py
+++ b/src/lvmcryo/tools.py
@@ -284,6 +284,7 @@ async def ensure_lock(
                     lockfile,
                     exit=exit,
                     console=console,
+                    on_release_callback=on_release_callback,
                 )
             )
         yield


### PR DESCRIPTION
This PR moves the main LN2 logic to a renamed `ln2_runner` which can be called programmatically. The CLI has been modified to use that function without changes in behaviour.